### PR TITLE
added test around sending custom request headers

### DIFF
--- a/node.js
+++ b/node.js
@@ -46,7 +46,7 @@ function requestTransport (options, prep) {
 	var req = {
 			url: prep.url,
 			method: options.method,
-			headers: options.headers ? Object.create(options.headers) : {}
+			headers: Object.assign({}, options.headers)
 		};
 	if (options.timeout) req.timeout = options.timeout;
 	req.body = io.processData({setRequestHeader: function (key, value) {

--- a/tests/test-io.js
+++ b/tests/test-io.js
@@ -165,5 +165,23 @@ unit.add(module, [
 			eval(t.TEST('isMultiPart.test(data.headers["content-type"])'));
 			x.done();
 		});
+	},
+	function test_io_custom_headers(t){
+		var x = t.startAsync();
+		io({
+			url:'http://localhost:3000/api',
+			headers: {
+				'Accept':'text/mod+plain',
+				'Content-Type':'text/plain'
+			},
+			method: 'POST',
+			data: 'Some Text'
+		}).then(function (data) {
+			eval(t.TEST('data.method === "POST"'));
+			eval(t.TEST('data.body === "Some Text"'));
+			eval(t.TEST('data.headers["content-type"] === "text/plain"'));
+			eval(t.TEST('data.headers["accept"] === "text/mod+plain"'));
+			x.done();
+		});
 	}
 ]);


### PR DESCRIPTION
Object.create was causing any headers that were passed in to io() to be moved into the headers prototype which then caused them to be ignored by request(). 

I inferred that the intent was to avoid pass-by-reference errors in the calling methods.  Given that headers should be either an object containing string properties, or an instance of Headers then using Object.assign will allow Object.keys(headers) to return all passed in properties and still create a shallow clone of the headers object if it is passed in